### PR TITLE
feat(node): support `closeAll` with `force` flag

### DIFF
--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -29,7 +29,7 @@ export interface NodeAdapter extends AdapterInstance {
     socket: Duplex,
     head: Buffer,
   ): Promise<void>;
-  closeAll: (code?: number, data?: string | Buffer) => void;
+  closeAll: (code?: number, data?: string | Buffer, force?: boolean) => void;
 }
 
 export interface NodeOptions extends AdapterOptions {
@@ -103,9 +103,13 @@ const nodeAdapter: Adapter<NodeAdapter, NodeOptions> = (options = {}) => {
         wss.emit("connection", ws, nodeReq);
       });
     },
-    closeAll: (code, data) => {
+    closeAll: (code, data, force) => {
       for (const client of wss.clients) {
-        client.close(code, data);
+        if (force) {
+          client.terminate();
+        } else {
+          client.close(code, data);
+        }
       }
     },
   };

--- a/test/adapters/node.test.ts
+++ b/test/adapters/node.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe } from "vitest";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { createServer, Server } from "node:http";
 import { getRandomPort, waitForPort } from "get-port-please";
 import nodeAdapter from "../../src/adapters/node";
@@ -44,5 +44,12 @@ describe("node", () => {
 
   wsTests(() => url, {
     adapter: "node",
+  });
+
+  test("forcefully terminates when force=true", async () => {
+    ws.closeAll(undefined, undefined, true);
+    for (const { websocket } of ws.peers) {
+      expect(websocket.readyState).toBe(WebSocket.CLOSING);
+    }
   });
 });


### PR DESCRIPTION
Adds a `force` flag to allow forcefully terminating web socket connections without waiting for the closing handshake.

Fixes #145 

