### PR TITLE
refactor!: remove `uncrypto` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,9 +84,6 @@
   "resolutions": {
     "crossws": "workspace:*"
   },
-  "dependencies": {
-    "uncrypto": "^0.1.3"
-  },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250506.0",
     "@types/bun": "^1.2.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,10 +10,6 @@ overrides:
 importers:
 
   .:
-    dependencies:
-      uncrypto:
-        specifier: ^0.1.3
-        version: 0.1.3
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20250506.0

--- a/src/message.ts
+++ b/src/message.ts
@@ -1,5 +1,4 @@
 import type { Peer } from "./peer.ts";
-import { randomUUID } from "uncrypto";
 import { kNodeInspect } from "./utils.ts";
 
 export class Message implements Partial<MessageEvent> {
@@ -30,7 +29,7 @@ export class Message implements Partial<MessageEvent> {
    */
   get id(): string {
     if (!this.#id) {
-      this.#id = randomUUID();
+      this.#id = crypto.randomUUID();
     }
     return this.#id;
   }

--- a/src/peer.ts
+++ b/src/peer.ts
@@ -1,5 +1,4 @@
 import type * as web from "../types/web.ts";
-import { randomUUID } from "uncrypto";
 import type { UpgradeRequest } from "./hooks.ts";
 import { kNodeInspect } from "./utils.ts";
 
@@ -31,7 +30,7 @@ export abstract class Peer<Internal extends AdapterInternal = AdapterInternal> {
    */
   get id(): string {
     if (!this._id) {
-      this._id = randomUUID();
+      this._id = crypto.randomUUID();
     }
     return this._id;
   }


### PR DESCRIPTION
Since Node.js 18 is EOL and all supported runtime versions support global Crypto, we can drop the `uncrypto` dependency.

If for any reason Node.js 18 support is still needed, a light global polyfill can be used. (that's why we don't enforce node version via `engines` field to allow such polyfill)

```js
import nodeCrypto from "node:crypto";

// globalThis.crypto support for Node.js 18
if (!globalThis.crypto) {
  globalThis.crypto = nodeCrypto as unknown as Crypto;
}
```