### PR TITLE
feat: stub full request interface

### DIFF
--- a/src/_request.ts
+++ b/src/_request.ts
@@ -1,0 +1,109 @@
+export const StubRequest = /* @__PURE__ */ (() => {
+  class StubRequest implements Omit<Request, "fetcher" | "cf"> {
+    url: string;
+
+    _signal?: AbortSignal;
+    _headers?: Headers;
+    _init?: RequestInit;
+
+    constructor(url: string, init: RequestInit = {}) {
+      this.url = url;
+      this._init = init;
+    }
+
+    get headers(): Headers {
+      if (!this._headers) {
+        this._headers = new Headers(this._init?.headers);
+      }
+      return this._headers;
+    }
+
+    clone() {
+      return new StubRequest(this.url, this._init) as any;
+    }
+
+    // --- dummy ---
+
+    get method() {
+      return "GET"; // https://github.com/h3js/crossws/issues/137
+    }
+
+    get signal() {
+      return (this._signal ??= new AbortSignal());
+    }
+
+    get cache() {
+      return "default" as const;
+    }
+
+    get credentials() {
+      return "same-origin" as const;
+    }
+
+    get destination() {
+      return "" as const;
+    }
+
+    get integrity() {
+      return "";
+    }
+
+    get keepalive() {
+      return false;
+    }
+
+    get redirect() {
+      return "follow" as const;
+    }
+
+    get mode() {
+      return "cors" as const;
+    }
+
+    get referrer() {
+      return "about:client";
+    }
+
+    get referrerPolicy() {
+      return "" as any;
+    }
+
+    get body() {
+      return null; // eslint-disable-line unicorn/no-null
+    }
+
+    get bodyUsed() {
+      return false;
+    }
+
+    arrayBuffer(): Promise<ArrayBuffer> {
+      return Promise.resolve(new ArrayBuffer(0));
+    }
+
+    blob() {
+      return Promise.resolve(new Blob());
+    }
+
+    bytes() {
+      return Promise.resolve(new Uint8Array());
+    }
+
+    formData() {
+      return Promise.resolve(new FormData());
+    }
+
+    json() {
+      return Promise.resolve(JSON.parse(""));
+    }
+
+    text() {
+      return Promise.resolve("");
+    }
+  }
+
+  Object.setPrototypeOf(StubRequest.prototype, globalThis.Request.prototype);
+
+  return StubRequest;
+})() as unknown as {
+  new (url: string, init?: RequestInit): Request;
+};

--- a/src/adapters/cloudflare-durable.ts
+++ b/src/adapters/cloudflare-durable.ts
@@ -7,6 +7,7 @@ import { adapterUtils } from "../adapter.ts";
 import { AdapterHookable } from "../hooks.ts";
 import { Message } from "../message.ts";
 import { Peer } from "../peer.ts";
+import { StubRequest } from "../_request.ts";
 
 type ResolveDurableStub = (
   req: CF.Request,
@@ -182,7 +183,8 @@ class CloudflareDurablePeer extends Peer<{
     const state = (ws.deserializeAttachment() || {}) as AttachedState;
     peer = ws._crosswsPeer = new CloudflareDurablePeer({
       ws: ws as CF.WebSocket,
-      request: (request as Request) || { url: state.u },
+      request:
+        (request as Request | undefined) || new StubRequest(state.u || ""),
       durable: durable as DurableObjectPub,
     });
     if (state.i) {

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -14,11 +14,12 @@ import type {
   WebSocketServer,
   WebSocket as WebSocketT,
 } from "../../types/ws";
+import { StubRequest } from "../_request.ts";
 
 // --- types ---
 
 type AugmentedReq = IncomingMessage & {
-  _request: NodeReqProxy;
+  _request: Request;
   _upgradeHeaders?: HeadersInit;
   _context: Peer["context"];
 };
@@ -121,7 +122,7 @@ export default nodeAdapter;
 
 class NodePeer extends Peer<{
   peers: Set<NodePeer>;
-  request: NodeReqProxy;
+  request: Request;
   nodeReq: IncomingMessage;
   ws: WebSocketT & { _peer?: NodePeer };
 }> {
@@ -174,32 +175,16 @@ class NodePeer extends Peer<{
 
 // --- web compat ---
 
-class NodeReqProxy {
+class NodeReqProxy extends StubRequest {
   _req: IncomingMessage;
-  _headers?: Headers;
-  _url?: string;
-
   constructor(req: IncomingMessage) {
+    const host = req.headers["host"] || "localhost";
+    const isSecure =
+      (req.socket as any)?.encrypted ??
+      req.headers["x-forwarded-proto"] === "https";
+    const url = `${isSecure ? "https" : "http"}://${host}${req.url}`;
+    super(url, { headers: req.headers as Record<string, string> });
     this._req = req;
-  }
-
-  get url(): string {
-    if (!this._url) {
-      const req = this._req;
-      const host = req.headers["host"] || "localhost";
-      const isSecure =
-        (req.socket as any)?.encrypted ??
-        req.headers["x-forwarded-proto"] === "https";
-      this._url = `${isSecure ? "https" : "http"}://${host}${req.url}`;
-    }
-    return this._url;
-  }
-
-  get headers(): Headers {
-    if (!this._headers) {
-      this._headers = new Headers(this._req.headers as HeadersInit);
-    }
-    return this._headers;
   }
 }
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -41,7 +41,7 @@ export class AdapterHookable {
   }
 
   async upgrade(
-    request: UpgradeRequest & { readonly context?: Peer["context"] },
+    request: Request & { readonly context?: Peer["context"] },
   ): Promise<{
     upgradeHeaders?: HeadersInit;
     endResponse?: Response;
@@ -59,7 +59,7 @@ export class AdapterHookable {
     try {
       const res = await this.callHook(
         "upgrade",
-        request as UpgradeRequest & { context: Peer["context"] },
+        request as Request & { context: Peer["context"] },
       );
       if (!res) {
         return { context };
@@ -101,13 +101,6 @@ export type ResolveHooks = (
 
 export type MaybePromise<T> = T | Promise<T>;
 
-export type UpgradeRequest =
-  | Request
-  | {
-      url: string;
-      headers: Headers;
-    };
-
 export type UpgradeError = Response | { readonly response: Response };
 
 export interface Hooks {
@@ -118,7 +111,7 @@ export interface Hooks {
    * @throws {Response}
    */
   upgrade: (
-    request: UpgradeRequest & { context: Peer["context"] },
+    request: Request & { context: Peer["context"] },
   ) => MaybePromise<Response | ResponseInit | void>;
 
   /** A message is received */

--- a/src/peer.ts
+++ b/src/peer.ts
@@ -1,10 +1,9 @@
 import type * as web from "../types/web.ts";
-import type { UpgradeRequest } from "./hooks.ts";
 import { kNodeInspect } from "./utils.ts";
 
 export interface AdapterInternal {
   ws: unknown;
-  request: UpgradeRequest;
+  request: Request;
   peers?: Set<Peer>;
   context?: Peer["context"];
 }
@@ -41,7 +40,7 @@ export abstract class Peer<Internal extends AdapterInternal = AdapterInternal> {
   }
 
   /** upgrade request */
-  get request(): UpgradeRequest {
+  get request(): Request {
     return this._internal.request;
   }
 


### PR DESCRIPTION
Real `Request` object is only available in upgrade stage of runtimes with web API. We stub it in other cases:

- Node/uWS req wrapper
- Hydrated peer from Bun and Cloudflare durable hooks

In this cases, request props such as `method` would be missing (resolves #137)

This PR uses a small stub wrapper as base class to cover this + allows depending on standard `Request` object in all hooks (which is essential for next steps of supporting srvx) 