### PR TITLE
feat: create `PeerContext` interface for type augmentation

### DIFF
--- a/src/adapters/bun.ts
+++ b/src/adapters/bun.ts
@@ -4,7 +4,7 @@ import { toBufferLike } from "../utils.ts";
 import { adapterUtils } from "../adapter.ts";
 import { AdapterHookable } from "../hooks.ts";
 import { Message } from "../message.ts";
-import { Peer } from "../peer.ts";
+import { Peer, type PeerContext } from "../peer.ts";
 
 // --- types ---
 
@@ -19,7 +19,7 @@ type ContextData = {
   peer?: BunPeer;
   request: Request;
   server?: Server;
-  context: Peer["context"];
+  context: PeerContext;
 };
 
 // --- adapter ---
@@ -96,7 +96,7 @@ class BunPeer extends Peer<{
     return this._internal.ws.remoteAddress;
   }
 
-  override get context(): Peer["context"] {
+  override get context(): PeerContext {
     return this._internal.ws.data.context;
   }
 

--- a/src/adapters/cloudflare.ts
+++ b/src/adapters/cloudflare.ts
@@ -4,7 +4,7 @@ import { adapterUtils } from "../adapter.ts";
 import { AdapterHookable } from "../hooks.ts";
 import { Message } from "../message.ts";
 import { WSError } from "../error.ts";
-import { Peer } from "../peer.ts";
+import { Peer, type PeerContext } from "../peer.ts";
 
 import type * as _cf from "@cloudflare/workers-types";
 
@@ -92,7 +92,7 @@ class CloudflarePeer extends Peer<{
   wsServer: _cf.WebSocket;
   cfEnv: unknown;
   cfCtx: _cf.ExecutionContext;
-  context: Peer["context"];
+  context: PeerContext;
 }> {
   send(data: unknown) {
     this._internal.wsServer.send(toBufferLike(data));

--- a/src/adapters/deno.ts
+++ b/src/adapters/deno.ts
@@ -4,7 +4,7 @@ import { adapterUtils } from "../adapter.ts";
 import { AdapterHookable } from "../hooks.ts";
 import { Message } from "../message.ts";
 import { WSError } from "../error.ts";
-import { Peer } from "../peer.ts";
+import { Peer, type PeerContext } from "../peer.ts";
 
 // --- types ---
 
@@ -76,7 +76,7 @@ class DenoPeer extends Peer<{
   request: Request;
   peers: Set<DenoPeer>;
   denoInfo: ServeHandlerInfo;
-  context: Peer["context"];
+  context: PeerContext;
 }> {
   override get remoteAddress() {
     return this._internal.denoInfo.remoteAddr?.hostname;

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -4,7 +4,7 @@ import { adapterUtils } from "../adapter.ts";
 import { AdapterHookable } from "../hooks.ts";
 import { Message } from "../message.ts";
 import { WSError } from "../error.ts";
-import { Peer } from "../peer.ts";
+import { Peer, type PeerContext } from "../peer.ts";
 
 import type { IncomingMessage } from "node:http";
 import type { Duplex } from "node:stream";
@@ -21,7 +21,7 @@ import { StubRequest } from "../_request.ts";
 type AugmentedReq = IncomingMessage & {
   _request: Request;
   _upgradeHeaders?: HeadersInit;
-  _context: Peer["context"];
+  _context: PeerContext;
 };
 
 export interface NodeAdapter extends AdapterInstance {

--- a/src/adapters/sse.ts
+++ b/src/adapters/sse.ts
@@ -4,7 +4,7 @@ import { toString } from "../utils.ts";
 import { adapterUtils } from "../adapter.ts";
 import { AdapterHookable } from "../hooks.ts";
 import { Message } from "../message.ts";
-import { Peer } from "../peer.ts";
+import { Peer, type PeerContext } from "../peer.ts";
 
 // --- types ---
 
@@ -102,7 +102,7 @@ class SSEPeer extends Peer<{
   request: Request;
   ws: SSEWebSocketStub;
   hooks: AdapterHookable;
-  context: Peer["context"];
+  context: PeerContext;
 }> {
   _sseStream: ReadableStream; // server -> client
   _sseStreamController?: ReadableStreamDefaultController;

--- a/src/adapters/uws.ts
+++ b/src/adapters/uws.ts
@@ -5,7 +5,7 @@ import { toBufferLike } from "../utils.ts";
 import { adapterUtils } from "../adapter.ts";
 import { AdapterHookable } from "../hooks.ts";
 import { Message } from "../message.ts";
-import { Peer } from "../peer.ts";
+import { Peer, type PeerContext } from "../peer.ts";
 import { StubRequest } from "../_request.ts";
 
 // --- types ---
@@ -16,7 +16,7 @@ type UserData = {
   res: uws.HttpResponse;
   protocol: string;
   extensions: string;
-  context: Peer["context"];
+  context: PeerContext;
 };
 
 type WebSocketHandler = uws.WebSocketBehavior<UserData>;
@@ -171,7 +171,7 @@ class UWSPeer extends Peer<{
     }
   }
 
-  override get context(): Peer["context"] {
+  override get context(): PeerContext {
     return this._internal.uwsData.context;
   }
 

--- a/src/adapters/uws.ts
+++ b/src/adapters/uws.ts
@@ -171,7 +171,7 @@ class UWSPeer extends Peer<{
     }
   }
 
-  override get context(): Record<string, unknown> {
+  override get context(): Peer["context"] {
     return this._internal.uwsData.context;
   }
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,6 +1,6 @@
 import type { AdapterOptions } from "./adapter.ts";
 import type { WSError } from "./error.ts";
-import type { Peer } from "./peer.ts";
+import type { Peer, PeerContext } from "./peer.ts";
 import type { Message } from "./message.ts";
 
 export class AdapterHookable {
@@ -42,11 +42,11 @@ export class AdapterHookable {
   }
 
   async upgrade(
-    request: Request & { readonly context?: Peer["context"] },
+    request: Request & { readonly context?: PeerContext },
   ): Promise<{
     upgradeHeaders?: HeadersInit;
     endResponse?: Response;
-    context: Peer["context"];
+    context: PeerContext;
   }> {
     let context = request.context;
     if (!context) {
@@ -60,7 +60,7 @@ export class AdapterHookable {
     try {
       const res = await this.callHook(
         "upgrade",
-        request as Request & { context?: Peer["context"] },
+        request as Request & { context?: PeerContext },
       );
       if (!res) {
         return { context };
@@ -97,7 +97,7 @@ export function defineHooks<T extends Partial<Hooks> = Partial<Hooks>>(
 }
 
 export type ResolveHooks = (
-  request: Request & { readonly context?: Peer["context"] },
+  request: Request & { readonly context?: PeerContext },
 ) => Partial<Hooks> | Promise<Partial<Hooks>>;
 
 export type MaybePromise<T> = T | Promise<T>;
@@ -112,7 +112,7 @@ export interface Hooks {
    */
   upgrade: (
     request: Request & {
-      readonly context?: Peer["context"];
+      readonly context?: PeerContext;
     },
   ) => MaybePromise<Response | ResponseInit | void>;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export type { Adapter, AdapterInstance, AdapterOptions } from "./adapter.ts";
 export type { Message } from "./message.ts";
 
 // Peer
-export type { Peer, AdapterInternal } from "./peer.ts";
+export type { Peer, PeerContext, AdapterInternal } from "./peer.ts";
 
 // Error
 export type { WSError } from "./error.ts";

--- a/src/peer.ts
+++ b/src/peer.ts
@@ -1,6 +1,8 @@
 import type * as web from "../types/web.ts";
 import { kNodeInspect } from "./utils.ts";
 
+export interface PeerContext extends Record<string, unknown> {}
+
 export interface AdapterInternal {
   ws: unknown;
   request: Request;
@@ -20,7 +22,7 @@ export abstract class Peer<Internal extends AdapterInternal = AdapterInternal> {
     this._internal = internal;
   }
 
-  get context(): Record<string, unknown> {
+  get context(): PeerContext {
     return (this._internal.context ??= {});
   }
 

--- a/src/peer.ts
+++ b/src/peer.ts
@@ -7,7 +7,7 @@ export interface AdapterInternal {
   ws: unknown;
   request: Request;
   peers?: Set<Peer>;
-  context?: Peer["context"];
+  context?: PeerContext;
 }
 
 export abstract class Peer<Internal extends AdapterInternal = AdapterInternal> {


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

Fixes #157 

Allow for augmenting the context of `Peer`

Example:
```ts
declare module 'crossws' {
  interface PeerContext {
    customData: string[]
  }
}
```

