### PR TITLE
refactor!: always pass `Request` as first param to `resolve`

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -97,7 +97,7 @@ export function defineHooks<T extends Partial<Hooks> = Partial<Hooks>>(
 }
 
 export type ResolveHooks = (
-  request: Request,
+  request: Request & { readonly context?: Peer["context"] },
 ) => Partial<Hooks> | Promise<Partial<Hooks>>;
 
 export type MaybePromise<T> = T | Promise<T>;

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -42,11 +42,11 @@ export class AdapterHookable {
   }
 
   async upgrade(
-    request: Request & { readonly context?: Record<string, unknown> },
+    request: Request & { readonly context?: Peer["context"] },
   ): Promise<{
     upgradeHeaders?: HeadersInit;
     endResponse?: Response;
-    context: Record<string, unknown>;
+    context: Peer["context"];
   }> {
     let context = request.context;
     if (!context) {
@@ -60,7 +60,7 @@ export class AdapterHookable {
     try {
       const res = await this.callHook(
         "upgrade",
-        request as Request & { context: Record<string, unknown> },
+        request as Request & { context?: Peer["context"] },
       );
       if (!res) {
         return { context };
@@ -105,15 +105,14 @@ export type MaybePromise<T> = T | Promise<T>;
 export type UpgradeError = Response | { readonly response: Response };
 
 export interface Hooks {
-  /** Upgrading */
   /**
-   *
+   * Upgrading a request to a WebSocket connection.
    * @param request
    * @throws {Response}
    */
   upgrade: (
     request: Request & {
-      readonly context?: Record<string, unknown>;
+      readonly context?: Peer["context"];
     },
   ) => MaybePromise<Response | ResponseInit | void>;
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -113,7 +113,7 @@ export interface Hooks {
    */
   upgrade: (
     request: Request & {
-      context: { readonly context?: Record<string, unknown> };
+      readonly context?: Record<string, unknown>;
     },
   ) => MaybePromise<Response | ResponseInit | void>;
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -20,7 +20,8 @@ export class AdapterHookable {
     const globalPromise = globalHook?.(arg1 as any, arg2 as any);
 
     // Resolve hooks for request
-    const resolveHooksPromise = this.options.resolve?.(arg1);
+    const request = (arg1 as Peer).request || arg1;
+    const resolveHooksPromise = this.options.resolve?.(request);
     if (!resolveHooksPromise) {
       return globalPromise as any; // Fast path: no hooks to resolve
     }
@@ -96,7 +97,7 @@ export function defineHooks<T extends Partial<Hooks> = Partial<Hooks>>(
 }
 
 export type ResolveHooks = (
-  info: RequestInit | Peer,
+  request: Request,
 ) => Partial<Hooks> | Promise<Partial<Hooks>>;
 
 export type MaybePromise<T> = T | Promise<T>;

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -42,11 +42,11 @@ export class AdapterHookable {
   }
 
   async upgrade(
-    request: Request & { readonly context?: Peer["context"] },
+    request: Request & { readonly context?: Record<string, unknown> },
   ): Promise<{
     upgradeHeaders?: HeadersInit;
     endResponse?: Response;
-    context: Peer["context"];
+    context: Record<string, unknown>;
   }> {
     let context = request.context;
     if (!context) {
@@ -60,7 +60,7 @@ export class AdapterHookable {
     try {
       const res = await this.callHook(
         "upgrade",
-        request as Request & { context: Peer["context"] },
+        request as Request & { context: Record<string, unknown> },
       );
       if (!res) {
         return { context };
@@ -112,7 +112,9 @@ export interface Hooks {
    * @throws {Response}
    */
   upgrade: (
-    request: Request & { context: Peer["context"] },
+    request: Request & {
+      context: { readonly context?: Record<string, unknown> };
+    },
   ) => MaybePromise<Response | ResponseInit | void>;
 
   /** A message is received */

--- a/test/fixture/_shared.ts
+++ b/test/fixture/_shared.ts
@@ -72,7 +72,7 @@ export function createDemo<T extends Adapter<any, any>>(
           },
         };
       }
-      req.context.test = "1";
+      req.context!.test = "1";
       return {
         headers: {
           "x-powered-by": "cross-ws",


### PR DESCRIPTION
Custom `resolve` hook could accept a request-like interface, either a Peer (with `.url`, `.headers`) or RequestInit with similar props.

Now we have standard `Request` interface (#156) accessible from `peer.request` also, we can always pass it as the canonical argument to resolve method.

Note: Although it is not a breaking change, it has small behavior change where we don't pass peer to resolve, which is why releasing as major version.