### PR TITLE
feat!: namespaced pub/sub peers

### DIFF
--- a/docs/1.guide/2.hooks.md
+++ b/docs/1.guide/2.hooks.md
@@ -16,10 +16,11 @@ import { defineHooks } from "crossws";
 
 const hooks = defineHooks({
   upgrade(req) {
-    console.log(`[ws] upgrading ${req.url}...`)
+    console.log(`[ws] upgrading ${req.url}...`);
     return {
-      headers: {}
-    }
+      // namespace: new URL(req.url).pathname
+      headers: {},
+    };
   },
 
   open(peer) {

--- a/docs/1.guide/3.peer.md
+++ b/docs/1.guide/3.peer.md
@@ -46,6 +46,10 @@ The context is an object that contains arbitrary information about the request.
 
 All topics, this peer has been subscribed to.
 
+### `peer.namespace`
+
+Peer's pubsub namespace.
+
 ## Instance methods
 
 ### `peer.send(message, { compress? })`

--- a/docs/1.guide/5.pubsub.md
+++ b/docs/1.guide/5.pubsub.md
@@ -10,6 +10,11 @@ crossws supports native pub-sub API integration. A [peer](/guide/peer) can be su
 import { defineHooks } from "crossws";
 
 const hooks = defineHooks({
+  upgrade(req) {
+    return {
+      // namespace: new URL(req.url).pathname
+    };
+  },
   open(peer) {
     // Send welcome to the new client
     peer.send("Welcome to the server!");

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -30,7 +30,10 @@ export function getPeers<T extends Peer = Peer>(
   globalPeers: Map<string, Set<T>>,
   namespace: string,
 ): Set<T> {
-  let peers = globalPeers.get(namespace || "");
+  if (!namespace) {
+    throw new Error("Websocket publish namespace missing.");
+  }
+  let peers = globalPeers.get(namespace);
   if (!peers) {
     peers = new Set<T>();
     globalPeers.set(namespace, peers);

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -1,34 +1,61 @@
 import type { Hooks, ResolveHooks } from "./hooks.ts";
 import type { Peer } from "./peer.ts";
 
-export function adapterUtils(peers: Set<Peer>): AdapterInstance {
+export function adapterUtils(
+  globalPeers: Map<string, Set<Peer>>,
+): AdapterInstance {
   return {
-    peers,
+    peers: globalPeers,
     publish(topic: string, message: any, options) {
-      let firstPeerWithTopic: Peer | undefined;
-      for (const peer of peers) {
-        if (peer.topics.has(topic)) {
-          firstPeerWithTopic = peer;
-          break;
+      for (const peers of options?.group
+        ? [globalPeers.get(options.group) || []]
+        : globalPeers.values()) {
+        let firstPeerWithTopic: Peer | undefined;
+        for (const peer of peers) {
+          if (peer.topics.has(topic)) {
+            firstPeerWithTopic = peer;
+            break;
+          }
         }
-      }
-      if (firstPeerWithTopic) {
-        firstPeerWithTopic.send(message, options);
-        firstPeerWithTopic.publish(topic, message, options);
+        if (firstPeerWithTopic) {
+          firstPeerWithTopic.send(message, options);
+          firstPeerWithTopic.publish(topic, message, options);
+        }
       }
     },
   } satisfies AdapterInstance;
 }
 
+export function getNamespace(opts: AdapterOptions, request: Request) {
+  return opts.getNamespace?.(request) ?? new URL(request.url).pathname;
+}
+
+export function getPeers<T extends Peer = Peer>(
+  globalPeers: Map<string, Set<T>>,
+  namespace: string,
+): Set<T> {
+  let peers = globalPeers.get(namespace || "");
+  if (!peers) {
+    peers = new Set<T>();
+    globalPeers.set(namespace, peers);
+  }
+  return peers;
+}
+
 // --- types ---
 
 export interface AdapterInstance {
-  readonly peers: Set<Peer>;
-  readonly publish: Peer["publish"];
+  readonly peers: Map<string, Set<Peer>>;
+  readonly publish: (
+    topic: string,
+    data: unknown,
+    options?: { compress?: boolean; group?: string },
+  ) => void;
 }
 
 export interface AdapterOptions {
   resolve?: ResolveHooks;
+  getNamespace?: (request: Request) => string;
   hooks?: Partial<Hooks>;
 }
 

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -7,8 +7,8 @@ export function adapterUtils(
   return {
     peers: globalPeers,
     publish(topic: string, message: any, options) {
-      for (const peers of options?.group
-        ? [globalPeers.get(options.group) || []]
+      for (const peers of options?.namespace
+        ? [globalPeers.get(options.namespace) || []]
         : globalPeers.values()) {
         let firstPeerWithTopic: Peer | undefined;
         for (const peer of peers) {
@@ -49,7 +49,7 @@ export interface AdapterInstance {
   readonly publish: (
     topic: string,
     data: unknown,
-    options?: { compress?: boolean; group?: string },
+    options?: { compress?: boolean; namespace?: string },
   ) => void;
 }
 

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -26,10 +26,6 @@ export function adapterUtils(
   } satisfies AdapterInstance;
 }
 
-export function getNamespace(opts: AdapterOptions, request: Request) {
-  return opts.getNamespace?.(request) ?? new URL(request.url).pathname;
-}
-
 export function getPeers<T extends Peer = Peer>(
   globalPeers: Map<string, Set<T>>,
   namespace: string,

--- a/src/adapters/bun.ts
+++ b/src/adapters/bun.ts
@@ -1,7 +1,7 @@
 import type { WebSocketHandler, ServerWebSocket, Server } from "bun";
 import type { AdapterOptions, AdapterInstance, Adapter } from "../adapter.ts";
 import { toBufferLike } from "../utils.ts";
-import { adapterUtils, getNamespace, getPeers } from "../adapter.ts";
+import { adapterUtils, getPeers } from "../adapter.ts";
 import { AdapterHookable } from "../hooks.ts";
 import { Message } from "../message.ts";
 import { Peer, type PeerContext } from "../peer.ts";

--- a/src/adapters/bun.ts
+++ b/src/adapters/bun.ts
@@ -1,7 +1,7 @@
 import type { WebSocketHandler, ServerWebSocket, Server } from "bun";
 import type { AdapterOptions, AdapterInstance, Adapter } from "../adapter.ts";
 import { toBufferLike } from "../utils.ts";
-import { adapterUtils } from "../adapter.ts";
+import { adapterUtils, getNamespace, getPeers } from "../adapter.ts";
 import { AdapterHookable } from "../hooks.ts";
 import { Message } from "../message.ts";
 import { Peer, type PeerContext } from "../peer.ts";
@@ -17,6 +17,7 @@ export interface BunOptions extends AdapterOptions {}
 
 type ContextData = {
   peer?: BunPeer;
+  namespace: string;
   request: Request;
   server?: Server;
   context: PeerContext;
@@ -34,11 +35,11 @@ const bunAdapter: Adapter<BunAdapter, BunOptions> = (options = {}) => {
   }
 
   const hooks = new AdapterHookable(options);
-  const peers = new Set<BunPeer>();
+  const globalPeers = new Map<string, Set<BunPeer>>();
   return {
-    ...adapterUtils(peers),
+    ...adapterUtils(globalPeers),
     async handleUpgrade(request, server) {
-      const { upgradeHeaders, endResponse, context } =
+      const { upgradeHeaders, endResponse, context, namespace } =
         await hooks.upgrade(request);
       if (endResponse) {
         return endResponse;
@@ -48,6 +49,7 @@ const bunAdapter: Adapter<BunAdapter, BunOptions> = (options = {}) => {
           server,
           request,
           context,
+          namespace,
         } satisfies ContextData,
         headers: upgradeHeaders,
       });
@@ -58,15 +60,18 @@ const bunAdapter: Adapter<BunAdapter, BunOptions> = (options = {}) => {
     },
     websocket: {
       message: (ws, message) => {
+        const peers = getPeers(globalPeers, ws.data.namespace);
         const peer = getPeer(ws, peers);
         hooks.callHook("message", peer, new Message(message, peer));
       },
       open: (ws) => {
+        const peers = getPeers(globalPeers, ws.data.namespace);
         const peer = getPeer(ws, peers);
         peers.add(peer);
         hooks.callHook("open", peer);
       },
       close: (ws, code, reason) => {
+        const peers = getPeers(globalPeers, ws.data.namespace);
         const peer = getPeer(ws, peers);
         peers.delete(peer);
         hooks.callHook("close", peer, { code, reason });
@@ -83,19 +88,22 @@ function getPeer(
   ws: ServerWebSocket<ContextData>,
   peers: Set<BunPeer>,
 ): BunPeer {
-  if (ws.data?.peer) {
+  if (ws.data.peer) {
     return ws.data.peer;
   }
-  const peer = new BunPeer({ ws, request: ws.data.request, peers });
-  ws.data = {
-    ...ws.data,
-    peer,
-  };
+  const peer = new BunPeer({
+    ws,
+    request: ws.data.request,
+    peers,
+    namespace: ws.data.namespace,
+  });
+  ws.data.peer = peer;
   return peer;
 }
 
 class BunPeer extends Peer<{
   ws: ServerWebSocket<ContextData>;
+  namespace: string;
   request: Request;
   peers: Set<BunPeer>;
 }> {

--- a/src/adapters/cloudflare-durable.ts
+++ b/src/adapters/cloudflare-durable.ts
@@ -191,7 +191,7 @@ class CloudflareDurablePeer extends Peer<{
       ws: ws as CF.WebSocket,
       request:
         (request as Request | undefined) || new StubRequest(state.u || ""),
-      namespace: namespace || state.n || "_",
+      namespace: namespace || state.n || "" /* later throws error if empty */,
       durable: durable as DurableObjectPub,
     });
     if (state.i) {

--- a/src/adapters/cloudflare-durable.ts
+++ b/src/adapters/cloudflare-durable.ts
@@ -3,7 +3,7 @@ import type { DurableObject } from "cloudflare:workers";
 import type { AdapterOptions, AdapterInstance, Adapter } from "../adapter.ts";
 import type * as web from "../../types/web.ts";
 import { toBufferLike } from "../utils.ts";
-import { adapterUtils } from "../adapter.ts";
+import { adapterUtils, getPeers } from "../adapter.ts";
 import { AdapterHookable } from "../hooks.ts";
 import { Message } from "../message.ts";
 import { Peer } from "../peer.ts";
@@ -49,7 +49,7 @@ const cloudflareDurableAdapter: Adapter<
   CloudflareOptions
 > = (opts = {}) => {
   const hooks = new AdapterHookable(opts);
-  const peers = new Set<CloudflareDurablePeer>();
+  const globalPeers = new Map<string, Set<CloudflareDurablePeer>>();
 
   const resolveDurableStub: ResolveDurableStub =
     opts.resolveDurableStub ||
@@ -66,7 +66,7 @@ const cloudflareDurableAdapter: Adapter<
     });
 
   return {
-    ...adapterUtils(peers),
+    ...adapterUtils(globalPeers),
     handleUpgrade: async (req, env, context) => {
       const stub = await resolveDurableStub(req as CF.Request, env, context);
       return stub.fetch(req as CF.Request) as unknown as Response;
@@ -75,12 +75,14 @@ const cloudflareDurableAdapter: Adapter<
       // placeholder
     },
     handleDurableUpgrade: async (obj, request) => {
-      const { upgradeHeaders, endResponse } = await hooks.upgrade(
+      const { upgradeHeaders, endResponse, namespace } = await hooks.upgrade(
         request as Request,
       );
       if (endResponse) {
         return endResponse;
       }
+
+      const peers = getPeers(globalPeers, namespace);
 
       const pair = new WebSocketPair();
       const client = pair[0];
@@ -89,6 +91,7 @@ const cloudflareDurableAdapter: Adapter<
         obj,
         server as unknown as CF.WebSocket,
         request,
+        namespace,
       );
       peers.add(peer);
       (obj as DurableObjectPub).ctx.acceptWebSocket(server);
@@ -107,6 +110,7 @@ const cloudflareDurableAdapter: Adapter<
     },
     handleDurableClose: async (obj, ws, code, reason, wasClean) => {
       const peer = CloudflareDurablePeer._restore(obj, ws as CF.WebSocket);
+      const peers = getPeers(globalPeers, peer.namespace);
       peers.delete(peer);
       const details = { code, reason, wasClean };
       await hooks.callHook("close", peer, details);
@@ -123,6 +127,7 @@ class CloudflareDurablePeer extends Peer<{
   request: Request;
   peers?: never;
   durable: DurableObjectPub;
+  namespace: string;
 }> {
   override get peers() {
     return new Set(
@@ -175,6 +180,7 @@ class CloudflareDurablePeer extends Peer<{
     durable: DurableObject,
     ws: AugmentedWebSocket,
     request?: Request | CF.Request,
+    namespace?: string,
   ): CloudflareDurablePeer {
     let peer = ws._crosswsPeer;
     if (peer) {
@@ -185,6 +191,7 @@ class CloudflareDurablePeer extends Peer<{
       ws: ws as CF.WebSocket,
       request:
         (request as Request | undefined) || new StubRequest(state.u || ""),
+      namespace: namespace || state.n || "_",
       durable: durable as DurableObjectPub,
     });
     if (state.i) {
@@ -236,6 +243,8 @@ type AttachedState = {
   i?: string;
   /** Request url */
   u?: string;
+  /** Connection namespace */
+  n?: string;
 };
 
 export interface CloudflareDurableAdapter extends AdapterInstance {

--- a/src/adapters/sse.ts
+++ b/src/adapters/sse.ts
@@ -1,7 +1,7 @@
 import type { AdapterOptions, AdapterInstance, Adapter } from "../adapter.ts";
 import type * as web from "../../types/web.ts";
 import { toString } from "../utils.ts";
-import { adapterUtils } from "../adapter.ts";
+import { adapterUtils, getPeers } from "../adapter.ts";
 import { AdapterHookable } from "../hooks.ts";
 import { Message } from "../message.ts";
 import { Peer, type PeerContext } from "../peer.ts";
@@ -21,13 +21,13 @@ export interface SSEOptions extends AdapterOptions {
 // https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events
 const sseAdapter: Adapter<SSEAdapter, SSEOptions> = (opts = {}) => {
   const hooks = new AdapterHookable(opts);
-  const peers = new Set<SSEPeer>();
+  const globalPeers = new Map<string, Set<SSEPeer>>();
   const peersMap = opts.bidir ? new Map<string, SSEPeer>() : undefined;
 
   return {
-    ...adapterUtils(peers),
+    ...adapterUtils(globalPeers),
     fetch: async (request: Request) => {
-      const { upgradeHeaders, endResponse, context } =
+      const { upgradeHeaders, endResponse, context, namespace } =
         await hooks.upgrade(request);
       if (endResponse) {
         return endResponse;
@@ -55,6 +55,7 @@ const sseAdapter: Adapter<SSEAdapter, SSEOptions> = (opts = {}) => {
       } else {
         // Add a new peer
         const ws = new SSEWebSocketStub();
+        const peers = getPeers(globalPeers, namespace);
         peer = new SSEPeer({
           peers,
           peersMap,
@@ -62,6 +63,7 @@ const sseAdapter: Adapter<SSEAdapter, SSEOptions> = (opts = {}) => {
           hooks,
           ws,
           context,
+          namespace,
         });
         peers.add(peer);
         if (opts.bidir) {
@@ -103,6 +105,7 @@ class SSEPeer extends Peer<{
   ws: SSEWebSocketStub;
   hooks: AdapterHookable;
   context: PeerContext;
+  namespace: string;
 }> {
   _sseStream: ReadableStream; // server -> client
   _sseStreamController?: ReadableStreamDefaultController;

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -128,7 +128,7 @@ export interface Hooks {
     request: Request & {
       readonly context?: PeerContext;
     },
-  ) => MaybePromise<Response | (ResponseInit & { namespace: string }) | void>;
+  ) => MaybePromise<Response | (ResponseInit & { namespace?: string }) | void>;
 
   /** A message is received */
   message: (peer: Peer, message: Message) => MaybePromise<void>;

--- a/src/peer.ts
+++ b/src/peer.ts
@@ -6,6 +6,7 @@ export interface PeerContext extends Record<string, unknown> {}
 export interface AdapterInternal {
   ws: unknown;
   request: Request;
+  namespace: string;
   peers?: Set<Peer>;
   context?: PeerContext;
 }
@@ -24,6 +25,10 @@ export abstract class Peer<Internal extends AdapterInternal = AdapterInternal> {
 
   get context(): PeerContext {
     return (this._internal.context ??= {});
+  }
+
+  get namespace(): string {
+    return this._internal.namespace;
   }
 
   /**

--- a/test/_utils.ts
+++ b/test/_utils.ts
@@ -4,6 +4,7 @@ import { execa, type ResultPromise as ExecaRes } from "execa";
 import { fileURLToPath } from "node:url";
 import { getRandomPort, waitForPort } from "get-port-please";
 import { wsTests } from "./tests";
+import type { Peer } from "../src";
 
 const fixtureDir = fileURLToPath(new URL("fixture", import.meta.url));
 

--- a/test/adapters/node.test.ts
+++ b/test/adapters/node.test.ts
@@ -16,7 +16,9 @@ describe("node", () => {
       if (req.url === "/peers") {
         return res.end(
           JSON.stringify({
-            peers: [...ws.peers].map((p) => p.id),
+            peers: [...ws.peers].flatMap(([namespace, peers]) =>
+              [...peers].map((p) => `${namespace}:${p.id}`),
+            ),
           }),
         );
       } else if (req.url!.startsWith("/publish")) {
@@ -48,8 +50,10 @@ describe("node", () => {
 
   test("forcefully terminates when force=true", async () => {
     ws.closeAll(undefined, undefined, true);
-    for (const { websocket } of ws.peers) {
-      expect(websocket.readyState).toBe(WebSocket.CLOSING);
+    for (const [_ns, peers] of ws.peers) {
+      for (const peer of peers) {
+        expect(peer.websocket.readyState).toBe(2 /* CLOSING */);
+      }
     }
   });
 });

--- a/test/adapters/uws.test.ts
+++ b/test/adapters/uws.test.ts
@@ -23,7 +23,11 @@ describe("uws", () => {
       let resBody = "OK";
       const url = req.getUrl();
       if (url === "/peers") {
-        resBody = JSON.stringify({ peers: [...ws.peers].map((p) => p.id) });
+        resBody = JSON.stringify({
+          peers: [...ws.peers].flatMap(([namespace, peers]) =>
+            [...peers].map((p) => `${namespace}:${p.id}`),
+          ),
+        });
       } else if (url === "/publish") {
         const q = new URLSearchParams(req.getQuery());
         const topic = q.get("topic") || "";

--- a/test/fixture/_shared.ts
+++ b/test/fixture/_shared.ts
@@ -13,7 +13,9 @@ export function createDemo<T extends Adapter<any, any>>(
 ): ReturnType<T> {
   const hooks = defineHooks({
     open(peer) {
-      peer.send(`Welcome to the server ${peer}!`);
+      peer.send(
+        `Welcome to the server ${peer}! (namespace: ${peer.namespace})`,
+      );
       peer.subscribe("chat");
       peer.publish("chat", `${peer} joined!`);
     },
@@ -96,7 +98,9 @@ export function handleDemoRoutes(
   if (url.pathname === "/peers") {
     return new Response(
       JSON.stringify({
-        peers: [...ws.peers].map((p) => p.id),
+        peers: [...ws.peers].flatMap(([namespace, peers]) =>
+          [...peers].map((p) => `${namespace}:${p.id}`),
+        ),
       }),
     );
   } else if (url.pathname === "/publish") {


### PR DESCRIPTION
In the current version of crossws, there is one `peers` global set per server. Publishing to the same "topic", published to all peers of the same topic.

While it works in simple servers with a single set of hooks, when using dynamic hooks (using [resolver](https://crossws.h3.dev/guide/resolver)), it makes sense that each peer only subscribe and publish to relevant peers and topics don't overlap.

This PR segments global peers into "namespaces". By default, the request "pathname" is used for namespace, so peers connected to `/_ws/room1` and `/_ws/room2` are isolated from each other (**BREAKING CHANGE**).

It is possible to have customized namespace logic based on request:

- Using adapter option `getNamespace: (req: Request) => string)`
- Using `upgrade(req)` hook by returning `{ namespace }`

Global `.publish(topic, message)` still publishes to all peers, but can specify a namespace using `.publish(topic, message, { namespace })`
