### PR TITLE
feat!: support returning context from `upgrade` hook

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -42,7 +42,7 @@ export class AdapterHookable {
   }
 
   async upgrade(
-    request: Request & { readonly context?: PeerContext },
+    request: Request & { readonly context?: Record<string, unknown> },
   ): Promise<{
     context: PeerContext;
     namespace: string;
@@ -52,14 +52,7 @@ export class AdapterHookable {
     let namespace =
       this.options.getNamespace?.(request) ?? new URL(request.url).pathname;
 
-    let context = request.context;
-    if (!context) {
-      context = {};
-      Object.defineProperty(request, "context", {
-        enumerable: true,
-        value: context,
-      });
-    }
+    const context = { ...request.context };
 
     try {
       const res = await this.callHook(
@@ -71,6 +64,12 @@ export class AdapterHookable {
       }
       if ((res as { namespace?: string }).namespace) {
         namespace = (res as { namespace: string }).namespace;
+      }
+      if ((res as { context?: Record<string, unknown> }).context) {
+        Object.assign(
+          context,
+          (res as { context?: Record<string, unknown> }).context,
+        );
       }
       if ((res as Response).ok === false) {
         return { context, namespace, endResponse: res as Response };
@@ -120,13 +119,14 @@ export interface Hooks {
    * - You can throw a Response to abort the upgrade.
    * - You can return { headers } to modify the response.
    * - You can return { namespace } to change the pub/sub namespace.
+   * - You can return { context } to provide a custom peer context.
    *
    * @param request
    * @throws {Response}
    */
   upgrade: (
     request: Request & {
-      readonly context?: PeerContext;
+      readonly context?: Record<string, unknown>;
     },
   ) => MaybePromise<Response | (ResponseInit & { namespace?: string }) | void>;
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -128,7 +128,11 @@ export interface Hooks {
     request: Request & {
       readonly context?: Record<string, unknown>;
     },
-  ) => MaybePromise<Response | (ResponseInit & { namespace?: string }) | void>;
+  ) => MaybePromise<
+    | Response
+    | (ResponseInit & { namespace?: string; context?: PeerContext })
+    | void
+  >;
 
   /** A message is received */
   message: (peer: Peer, message: Message) => MaybePromise<void>;

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -52,7 +52,7 @@ export class AdapterHookable {
     let namespace =
       this.options.getNamespace?.(request) ?? new URL(request.url).pathname;
 
-    const context = { ...request.context };
+    const context = request.context || {};
 
     try {
       const res = await this.callHook(

--- a/test/fixture/_shared.ts
+++ b/test/fixture/_shared.ts
@@ -74,8 +74,8 @@ export function createDemo<T extends Adapter<any, any>>(
           },
         };
       }
-      req.context!.test = "1";
       return {
+        context: { test: "1" },
         headers: {
           "x-powered-by": "cross-ws",
           "set-cookie": "cross-ws=1; SameSite=None; Secure",


### PR DESCRIPTION
An update on top of #111

This PR allows a new way of returning `{ context }` from `upgrade(req)` hook to provide custom additional peer context.

Mainly for backward compatibility, we still support (nonstandard) `request.context` (example use: https://github.com/h3js/h3/pull/960), but the difference/behavior change is that we won't anymore augment/pollute `request.context` if it is not set. 
