### PR TITLE
refactor!: always terminate `upgrade` if `Response` is returned

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -71,8 +71,8 @@ export class AdapterHookable {
           (res as { context?: Record<string, unknown> }).context,
         );
       }
-      if ((res as Response).ok === false) {
-        return { context, namespace, endResponse: res as Response };
+      if (res instanceof Response) {
+        return { context, namespace, endResponse: res };
       }
       if (res.headers) {
         return {


### PR DESCRIPTION
In #91 we introduced a way for throwing error/responses to terminate upgrade cycle.

For returning, we only terminate when response is not oK (for backward compatibility as before, it was possible to return full response only for custom headers)

This PR is a breaking change to always terminate the upgrade if a `Response` is returned for consistency and also encouraging to use `{ headers, ... }` value for performance.