### PR TITLE
feat(cloudflare)!: support global publish via rpc

### DIFF
--- a/docs/2.adapters/cloudflare.md
+++ b/docs/2.adapters/cloudflare.md
@@ -53,6 +53,10 @@ export class $DurableObject extends DurableObject {
     return ws.handleDurableMessage(this, client, message);
   }
 
+  webSocketPublish(topic, message, opts) {
+    return ws.handleDurablePublish(this, topic, message, opts);
+  }
+
   webSocketClose(client, code, reason, wasClean) {
     return ws.handleDurableClose(this, client, code, reason, wasClean);
   }

--- a/test/fixture/cloudflare-durable.ts
+++ b/test/fixture/cloudflare-durable.ts
@@ -36,6 +36,10 @@ export class $DurableObject extends DurableObject {
     return ws.handleDurableUpgrade(this, request);
   }
 
+  webSocketPublish(topic: string, message: unknown, opts: any) {
+    return ws.handleDurablePublish(this, topic, message, opts);
+  }
+
   override async webSocketMessage(
     client: WebSocket,
     message: ArrayBuffer | string,

--- a/test/fixture/wrangler-durable.toml
+++ b/test/fixture/wrangler-durable.toml
@@ -1,6 +1,6 @@
 # https://developers.cloudflare.com/workers/wrangler/configuration/
 
-compatibility_date = "2024-01-01"
+compatibility_date = "2024-04-03"
 workers_dev = false
 
 main = "cloudflare-durable.ts"

--- a/test/fixture/wrangler.toml
+++ b/test/fixture/wrangler.toml
@@ -1,6 +1,6 @@
 # https://developers.cloudflare.com/workers/wrangler/configuration/
 
-compatibility_date = "2024-01-01"
+compatibility_date = "2024-04-03"
 workers_dev = false
 
 main = "cloudflare.ts"

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -175,7 +175,7 @@ export function wsTests(getURL: () => string, opts: WSTestOpts): void {
     expect(peers1).toMatchObject(peers2);
   });
 
-  test.skipIf(opts.adapter.startsWith("cloudflare"))(
+  test.skipIf(opts.adapter === "cloudflare" /* durable only */)(
     "publish to all peers from adapter",
     async () => {
       const ws1 = await wsConnect(getURL(), { skip: 1 });


### PR DESCRIPTION
This PR enables global `ws.publish(topic, message, opts)` to work with Cloudflare Durable Adapter out of the box.

When `ws.publish(...)` is called, the durable object stub is resolved and called with arguments using RPC. Then, in the context of the durable object, publishing happens.

Requirements:
- Compatibility date `>=2024-04-03` (or `rpc` compatibility flag)
- New `webSocketPublish` being exported from durable object calling `ws.handleDurablePublish` (see docs/example)

Breaking changes:
- Custom `resolveDurableStub(req, env, ctx)` should handle cases where `req` and `ctx` are undefined  