### PR TITLE
docs: Mention publish not broadcasting to sender

### DIFF
--- a/docs/1.guide/3.peer.md
+++ b/docs/1.guide/3.peer.md
@@ -80,7 +80,7 @@ Leave a broadcast channel.
 
 ### `peer.publish(channel, message)`
 
-broadcast a message to the channel.
+Broadcast a message to the channel. The peer that the publish is called on itself is excluded from the broadcast.
 
 :read-more{to="/guide/pubsub"}
 
@@ -108,7 +108,7 @@ To gracefully close the connection, use `peer.close()`.
 ## Compatibility
 
 |                             | [Bun][bun] | [Cloudflare][cfw] | [Cloudflare (durable)][cfd] | [Deno][deno] | [Node (ws)][nodews] | [Node (μWebSockets)][nodeuws] | [SSE][sse] |
-| --------------------------- | ---------- | ----------------- | --------------------------- | ------------ | ------------------- | ----------------------------- | ---------- |
+|-----------------------------|------------|-------------------|-----------------------------|--------------|---------------------|-------------------------------|------------|
 | `send()`                    | ✓          | ✓                 | ✓                           | ✓            | ✓                   | ✓                             | ✓          |
 | `publish()` / `subscribe()` | ✓          | ⨉                 | ✓ [^1]                      | ✓ [^1]       | ✓ [^1]              | ✓                             | ✓ [^1]     |
 | `close()`                   | ✓          | ✓                 | ✓                           | ✓            | ✓                   | ✓                             | ✓          |

--- a/docs/1.guide/5.pubsub.md
+++ b/docs/1.guide/5.pubsub.md
@@ -4,7 +4,7 @@ icon: simple-icons:googlepubsub
 
 # Pub / Sub
 
-crossws supports native pub-sub API integration. A [peer](/guide/peer) can be subscribed to a set of named channels using `peer.subscribe(<name>)`. Messages can be published to a channel using `peer.publish(<name>, <message>)`.
+crossws supports native pub-sub API integration. A [peer](/guide/peer) can be subscribed to a set of named channels using `peer.subscribe(<name>)`. Messages can be published to a channel using `peer.publish(<name>, <message>)`. When publishing to a channel, the peer that does the publish is excluded from the broadcast so it won't receive it's own message.
 
 ```js
 import { defineHooks } from "crossws";


### PR DESCRIPTION
Add a little note to the docs about `.publish()` not broadcasting to the sender.

Ref #172