### PR TITLE
fix(node): prevent repeated serve() calls from registering duplicate upgrade handlers (#205)

### DIFF
--- a/src/server/node.ts
+++ b/src/server/node.ts
@@ -5,6 +5,8 @@ import { defaultResolve } from "./_resolve";
 import type { Server, ServerPlugin, ServerOptions } from "srvx";
 import type { WSOptions, ServerWithWSOptions } from "./_types";
 
+const registeredServers = new WeakSet<object>();
+
 export function plugin(wsOpts: WSOptions): ServerPlugin {
   return (server) => {
     const ws = adapter({
@@ -14,15 +16,22 @@ export function plugin(wsOpts: WSOptions): ServerPlugin {
     });
     const originalServe = server.serve;
     server.serve = () => {
-      server.node?.server!.on("upgrade", (req, socket, head) => {
-        ws.handleUpgrade(
-          req,
-          socket,
-          head,
-          // @ts-expect-error (upgrade is not typed)
-          new NodeRequest({ req, upgrade: { socket, head } }),
-        );
-      });
+      const nodeServer = server.node?.server;
+      if (!registeredServers.has(server) && (!nodeServer || !registeredServers.has(nodeServer))) {
+        registeredServers.add(server);
+        if (nodeServer) {
+          registeredServers.add(nodeServer);
+        }
+        nodeServer?.on("upgrade", (req, socket, head) => {
+          ws.handleUpgrade(
+            req,
+            socket,
+            head,
+            // @ts-expect-error (upgrade is not typed)
+            new NodeRequest({ req, upgrade: { socket, head } }),
+          );
+        });
+      }
       return originalServe.call(server);
     };
   };

--- a/test/node-handler.test.ts
+++ b/test/node-handler.test.ts
@@ -113,3 +113,27 @@ test("fromNodeUpgradeHandler does not invoke node adapter's own handleUpgrade", 
   client.close();
   await once(client, "close");
 });
+
+test("repeated serve() calls do not register duplicate upgrade handlers", async () => {
+  const port = await getRandomPort("localhost");
+  const server = serve({
+    port,
+    hostname: "127.0.0.1",
+    fetch: () => new Response("ok"),
+    websocket: {
+      message(peer, message) {
+        peer.send(message.text());
+      },
+    },
+  });
+  currentServer = server;
+  await server.ready();
+
+  const initialListeners = server.node?.server?.listenerCount("upgrade") ?? 0;
+  expect(initialListeners).toBe(1);
+
+  // Repeated call to serve() should not add duplicate upgrade listeners
+  await server.serve();
+  const subsequentListeners = server.node?.server?.listenerCount("upgrade") ?? 0;
+  expect(subsequentListeners).toBe(1);
+});


### PR DESCRIPTION
Resolves #205

### Problem
In `src/server/node.ts`, `server.serve()` overrides `server.serve` and attaches an `"upgrade"` event listener to `server.node.server` on each invocation. When `serve()` is called multiple times on a server instance, duplicate upgrade handlers are registered, causing multiple handshakes and unexpected behavior.

### Solution
Track registered server instances using a `WeakSet` so that the `"upgrade"` event handler is attached to the underlying server exactly once, ignoring redundant registrations on repeated `serve()` invocations.

### Testing
- Added a unit test in `test/node-handler.test.ts` verifying that repeated `server.serve()` invocations do not increase the `"upgrade"` listener count.
- Ran full lint (`oxlint`, `oxfmt`), typecheck (`tsc`), and vitest suites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repeated server startup calls from registering duplicate WebSocket upgrade handlers.
  * Improved stability for applications that invoke server setup more than once.

* **Tests**
  * Added coverage to verify that repeated server setup maintains a single WebSocket upgrade listener.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->